### PR TITLE
Fix falcon mode Timestamp defalut 0 and Value 0 error

### DIFF
--- a/model/metric.go
+++ b/model/metric.go
@@ -44,9 +44,10 @@ func FmtFalconMetricValue(vs []*dataobj.MetricValue, step int64) []*fmodel.Metri
 		item := &fmodel.MetricValue{
 			Endpoint: v.Endpoint,
 			Metric:   v.Metric,
-			Value:    v.Value,
-			Tags:     v.Tags,
-			Step:     step,
+                        Value:    v.ValueUntyped,
+                        Tags:     v.Tags,
+                        Step:     step,
+                        Timestamp: v.Timestamp,
 		}
 		if v.CounterType == "SUBTRACT" {
 			item.Type = "COUNTER"


### PR DESCRIPTION
场景再现
目录结构如下；
```
ll
total 11412
-rwxr-xr-x 1 root root      376 Oct 29 11:34 collector_b.sh
-rwxrwxr-x 1 9990 9990      361 Oct 29 11:34 collector.sh
-rw-rw-r-- 1 9990 9990     2293 Oct 29 10:38 metrics
-rwxr-xr-x 1 root root 11673353 Oct 29 12:46 prometheus-exporter-collector
```

shell脚本
```
cat collector_b.sh
#!/bin/bash
./prometheus-exporter-collector -b falcon -s 60 << EOF
{
        "exporter_urls": [
                "http://127.0.0.1:8000/metrics"
        ],
        "append_tags": ["cluster=$(hostname | sed -r 's/[0-9]+$//')"],
        "endpoint": "$(hostname)",
        "ignore_metrics_prefix": ["go_", "prometheus_"],
        "metric_prefix": "",
        "metric_type": {},
        "default_mapping_metric_type": "COUNTER",
        "timeout": 500
}
EOF
```

创建测试数据
```
cat metrics
# HELP gt_test_prometheus_exporter_collector_gauge gauge test
# TYPE gt_test_prometheus_exporter_collector_gauge gauge
gt_test_prometheus_exporter_collector_gauge{num="42"} 42
gt_test_prometheus_exporter_collector_gauge{num="233"} 233
# HELP gt_test_prometheus_exporter_collector_counter counter test
# TYPE gt_test_prometheus_exporter_collector_counter counter
gt_test_prometheus_exporter_collector_counter{code="200"} 2
gt_test_prometheus_exporter_collector_counter{code="500"} 0
gt_test_prometheus_exporter_collector_counter{code="503"} 0
# HELP gt_test_prometheus_exporter_collector_histogram histogram test
# TYPE gt_test_prometheus_exporter_collector_histogram histogram
gt_test_prometheus_exporter_collector_histogram_bucket{le="1"} 0
gt_test_prometheus_exporter_collector_histogram_bucket{le="2"} 0
gt_test_prometheus_exporter_collector_histogram_bucket{le="4"} 0
gt_test_prometheus_exporter_collector_histogram_bucket{le="8"} 37
gt_test_prometheus_exporter_collector_histogram_bucket{le="16"} 120
gt_test_prometheus_exporter_collector_histogram_bucket{le="32"} 130
gt_test_prometheus_exporter_collector_histogram_bucket{le="64"} 141
gt_test_prometheus_exporter_collector_histogram_bucket{le="128"} 145
gt_test_prometheus_exporter_collector_histogram_bucket{le="256"} 145
gt_test_prometheus_exporter_collector_histogram_bucket{le="512"} 147
gt_test_prometheus_exporter_collector_histogram_bucket{le="+Inf"} 147
gt_test_prometheus_exporter_collector_histogram_sum 2921.69835069
gt_test_prometheus_exporter_collector_histogram_count 147
# HELP gt_test_prometheus_exporter_collector_summary summary test
# TYPE gt_test_prometheus_exporter_collector_summary summary
gt_test_prometheus_exporter_collector_summary{interval="15s",quantile="0.01"} 14.944968698
gt_test_prometheus_exporter_collector_summary{interval="15s",quantile="0.05"} 14.999947444
gt_test_prometheus_exporter_collector_summary{interval="15s",quantile="0.5"} 15.000022072
gt_test_prometheus_exporter_collector_summary{interval="15s",quantile="0.9"} 15.000074251
gt_test_prometheus_exporter_collector_summary{interval="15s",quantile="0.99"} 15.059536183
gt_test_prometheus_exporter_collector_summary_sum{interval="15s"} 1.0118885926432915e+08
gt_test_prometheus_exporter_collector_summary_count{interval="15s"} 6.745891e+06
```

启动一个服务在同级目录下启动服务
`python -m http.server`
然后运行脚本collector_b.sh，就可查看输出数据的时间戳和Value为0


