### PR TITLE
解决value带有Nan,+Inf和-Inf的metric

### DIFF
--- a/collector/parser.go
+++ b/collector/parser.go
@@ -34,11 +34,18 @@ func Parse(buf []byte) ([]*dataobj.MetricValue, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading text format failed: %s", err)
 	}
+
 	now = time.Now().Unix()
 	// read metrics
 	for basename, mf := range metricFamilies {
+
 		metrics := []*dataobj.MetricValue{}
 		for _, m := range mf.Metric {
+			// 丢弃value中带有Nan,+Inf和-Inf的metric
+			gv := m.Gauge.GetValue()
+			if math.IsInf(gv, 0) || math.IsNaN(gv) {
+				continue
+			}
 			// pass ignore metric
 			if filterIgnoreMetric(basename) {
 				continue


### PR DESCRIPTION
1. 当从url获取metric，value为Nan,+Inf和-Inf时，json无法解析.
2. 丢弃了这些metric